### PR TITLE
Fix scenario where shaders could have a shine above 1, replaced `shin…

### DIFF
--- a/game_data/base/liquids/water.txt
+++ b/game_data/base/liquids/water.txt
@@ -1,7 +1,8 @@
 name = Water
 description = Everyday body of water.
 
-shine_amount = 0.5
+shine_min_threshold = 0.75
+shine_max_threshold = 0.95
 body_color = 0 0 16 96
 shine_color = 255 255 255 255
 radar_color = 32 64 180

--- a/source/source/content/other/liquid.cpp
+++ b/source/source/content/other/liquid.cpp
@@ -36,7 +36,8 @@ void liquid::load_from_data_node(data_node* node, CONTENT_LOAD_LEVEL level) {
     rs.set("body_color", body_color);
     rs.set("shine_color", shine_color);
     rs.set("radar_color", radar_color);
-    rs.set("shine_amount", shine_amount);
+    rs.set("shine_min_threshold", shine_min_threshold);
+    rs.set("shine_max_threshold", shine_max_threshold);
     rs.set("distortion_amount", distortion_amount);
     rs.set("animation_speed", anim_speed);
 }

--- a/source/source/content/other/liquid.h
+++ b/source/source/content/other/liquid.h
@@ -49,8 +49,11 @@ struct liquid : public content {
     //Maximum displacement amount.
     point distortion_amount = point(14.0f, 4.0f);
     
-    //Noise threshold for how much of the liquid is covered in shines.
-    float shine_amount = 0.5f;
+    //Noise threshold for how much of the liquid will have no shines.
+    float shine_min_threshold = 0.5f;
+
+    //Noise threshold for how much of the liquid fully covered in shines.
+    float shine_max_threshold = 1.0f;
     
     //How fast the water animates.
     float anim_speed = 1;

--- a/source/source/core/drawing.cpp
+++ b/source/source/core/drawing.cpp
@@ -421,7 +421,8 @@ void draw_liquid(
     al_set_shader_float("opacity", liquid_opacity_mult);
     al_set_shader_float("sector_brightness", brightness_mult);
     al_set_shader_float_vector("sector_scroll", 2, &sector_scroll[0], 1);
-    al_set_shader_float("shine_amount", l_ptr->shine_amount);
+    al_set_shader_float("shine_min_threshold", l_ptr->shine_min_threshold);
+    al_set_shader_float("shine_max_threshold", l_ptr->shine_max_threshold);
     al_set_shader_float_vector("distortion_amount", 2, &distortion_amount[0], 1);
     al_set_shader_float_vector("surface_color", 4, &liquid_tint[0], 1);
     al_set_shader_float_vector("shine_color", 4, &shine_color[0], 1);


### PR DESCRIPTION
…e_amount` with min and max thresholds.