### PR TITLE
Fix a crash that occured when splitting path nodes

### DIFF
--- a/source/source/game_state/area_editor/event_handling.cpp
+++ b/source/source/game_state/area_editor/event_handling.cpp
@@ -462,9 +462,10 @@ void AreaEditor::handleLmbDoubleClick(const ALLEGRO_EVENT& ev) {
                             clickedELink->link1, clickedELink->link2,
                             snapPoint(game.editorsView.mouseCursorWorldPos)
                         );
-                    pathLinkSelection.setSingle(
+                    pathStopSelection.setSingle(
                         game.curArea->findPathStopIdx(newStop)
                     );
+                    pathLinkSelection.clear();
                     updateSelectionRequirements();
                     highlightedPathStop = newStop;
                     doFakeClick = true;


### PR DESCRIPTION
When splitting a path, it selected the link using the stop's index. This would cause a crash when there are more stops than links (such as splitting a link in an area with only 2 nodes).