### PR TITLE
Unify event handling for touched hazard events.

### DIFF
--- a/source/source/content/mob_script/gen_mob_fsm.cpp
+++ b/source/source/content/mob_script/gen_mob_fsm.cpp
@@ -622,15 +622,6 @@ void GenMobFsm::leaveHazard(ScriptVM* scriptVM, void* info1, void* info2) {
 }
 
 
-
-/**
- * @brief Generic handler for a mob leaving a hazard.
- *
- * @param scriptVM The script VM responsible.
- * @param info1 Unused.
- * @param info2 Unused.
- */
-
 /**
  * @brief Generic handler for a mob touching a spray.
  *

--- a/source/source/content/mob_script/gen_mob_fsm.cpp
+++ b/source/source/content/mob_script/gen_mob_fsm.cpp
@@ -548,19 +548,88 @@ void GenMobFsm::startBeingDelivered(
  * @brief Generic handler for a mob touching a hazard.
  *
  * @param scriptVM The script VM responsible.
- * @param info1 Unused.
- * @param info2 Unused.
+ * @param info1 Pointer to the hazard.
+ * @param info2 Pointer to the hitbox that caused this, if any.
  */
 void GenMobFsm::touchHazard(ScriptVM* scriptVM, void* info1, void* info2) {
+    Mob* mPtr = scriptVM->mob;
+    Hazard* hazPtr = (Hazard*) info1;
+    
     engineAssert(info1 != nullptr, scriptVM->fsm.getStateHistoryStr());
     
-    Hazard* h = (Hazard*) info1;
+    HitboxInteraction* hitboxInfo = (HitboxInteraction*) info2;
+    MobType::Vulnerability vuln = mPtr->getHazardVulnerability(hazPtr);
+    Mob* hitboxMob = nullptr;
+    if(hitboxInfo) hitboxMob = hitboxInfo->mob2;
     
-    forIdx(e, h->effects) {
-        scriptVM->mob->applyStatus(h->effects[e], false, true);
+    if(hazPtr->associatedLiquid) {
+        bool alreadyGenerating = false;
+        forIdx(g, mPtr->particleGenerators) {
+            if(
+                mPtr->particleGenerators[g].id ==
+                MOB_PARTICLE_GENERATOR_ID_WAVE_RING
+            ) {
+                alreadyGenerating = true;
+                break;
+            }
+        }
+        
+        if(!alreadyGenerating) {
+            ParticleGenerator pg =
+                standardParticleGenSetup(
+                    game.sysContentNames.parWaveRing, mPtr
+                );
+            pg.followZOffset = 1.0f;
+            adjustKeyframeInterpolatorValues<float>(
+                pg.baseParticle.size,
+            [ = ] (const float & f) { return f * mPtr->radius; }
+            );
+            pg.id = MOB_PARTICLE_GENERATOR_ID_WAVE_RING;
+            mPtr->particleGenerators.push_back(pg);
+        }
+    }
+
+    if(mPtr->invulnPeriod.timeLeft > 0) return;
+    if(vuln.effectMult == 0.0f) return;
+
+    if(!vuln.statusToApply || !vuln.statusOverrides) {
+        forIdx(e, hazPtr->effects) {
+            mPtr->applyStatus(hazPtr->effects[e], false, true, hitboxMob);
+        }
+    }
+    if(vuln.statusToApply) {
+        mPtr->applyStatus(vuln.statusToApply, false, true, hitboxMob);
     }
 }
 
+
+/**
+ * @brief Generic handler for a mob leaving a hazard.
+ *
+ * @param scriptVM The script VM responsible.
+ * @param info1 Points to the hazard.
+ * @param info2 Unused.
+ */
+void GenMobFsm::leaveHazard(ScriptVM* scriptVM, void* info1, void* info2) {
+    Mob* mPtr = scriptVM->mob;
+    Hazard* h = (Hazard*) info1;
+    
+    engineAssert(info1 != nullptr, scriptVM->fsm.getStateHistoryStr());
+    
+    if(h->associatedLiquid) {
+        mPtr->deleteParticleGenerator(MOB_PARTICLE_GENERATOR_ID_WAVE_RING);
+    }
+}
+
+
+
+/**
+ * @brief Generic handler for a mob leaving a hazard.
+ *
+ * @param scriptVM The script VM responsible.
+ * @param info1 Unused.
+ * @param info2 Unused.
+ */
 
 /**
  * @brief Generic handler for a mob touching a spray.

--- a/source/source/content/mob_script/gen_mob_fsm.hpp
+++ b/source/source/content/mob_script/gen_mob_fsm.hpp
@@ -32,5 +32,6 @@ void handleDelivery(ScriptVM* scriptVM, void* info1, void* info2);
 void loseMomentum(ScriptVM* scriptVM, void* info1, void* info2);
 void startBeingDelivered(ScriptVM* scriptVM, void* info1, void* info2);
 void touchHazard(ScriptVM* scriptVM, void* info1, void* info2);
+void leaveHazard(ScriptVM* scriptVM, void* info1, void* info2);
 void touchSpray(ScriptVM* scriptVM, void* info1, void* info2);
 }

--- a/source/source/content/mob_script/leader_fsm.cpp
+++ b/source/source/content/mob_script/leader_fsm.cpp
@@ -81,10 +81,10 @@ void LeaderFsm::createFsm(MobType* typ) {
             efc.run(LeaderFsm::startGoHere);
         }
         efc.newEvent(FSM_EV_TOUCHED_HAZARD); {
-            efc.run(LeaderFsm::touchedHazard);
+            efc.run(GenMobFsm::touchHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(LeaderFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(LeaderFsm::touchedSpray);
@@ -108,10 +108,10 @@ void LeaderFsm::createFsm(MobType* typ) {
             efc.changeState("ko");
         }
         efc.newEvent(FSM_EV_TOUCHED_HAZARD); {
-            efc.run(LeaderFsm::touchedHazard);
+            efc.run(GenMobFsm::touchHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(LeaderFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(LeaderFsm::touchedSpray);
@@ -183,10 +183,10 @@ void LeaderFsm::createFsm(MobType* typ) {
             efc.changeState("shaking");
         }
         efc.newEvent(FSM_EV_TOUCHED_HAZARD); {
-            efc.run(LeaderFsm::touchedHazard);
+            efc.run(GenMobFsm::touchHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(LeaderFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(LeaderFsm::touchedSpray);
@@ -237,10 +237,10 @@ void LeaderFsm::createFsm(MobType* typ) {
             efc.run(LeaderFsm::startGoHere);
         }
         efc.newEvent(FSM_EV_TOUCHED_HAZARD); {
-            efc.run(LeaderFsm::touchedHazard);
+            efc.run(GenMobFsm::touchHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(LeaderFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(LeaderFsm::touchedSpray);
@@ -283,10 +283,10 @@ void LeaderFsm::createFsm(MobType* typ) {
             efc.run(LeaderFsm::startGoHere);
         }
         efc.newEvent(FSM_EV_TOUCHED_HAZARD); {
-            efc.run(LeaderFsm::touchedHazard);
+            efc.run(GenMobFsm::touchHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(LeaderFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(LeaderFsm::touchedSpray);
@@ -335,10 +335,10 @@ void LeaderFsm::createFsm(MobType* typ) {
             efc.changeState("ko");
         }
         efc.newEvent(FSM_EV_TOUCHED_HAZARD); {
-            efc.run(LeaderFsm::touchedHazard);
+            efc.run(GenMobFsm::touchHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(LeaderFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(LeaderFsm::touchedSpray);
@@ -388,10 +388,10 @@ void LeaderFsm::createFsm(MobType* typ) {
             efc.run(LeaderFsm::startGoHere);
         }
         efc.newEvent(FSM_EV_TOUCHED_HAZARD); {
-            efc.run(LeaderFsm::touchedHazard);
+            efc.run(GenMobFsm::touchHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(LeaderFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(LeaderFsm::touchedSpray);
@@ -428,10 +428,10 @@ void LeaderFsm::createFsm(MobType* typ) {
             efc.run(LeaderFsm::beAttacked);
         }
         efc.newEvent(FSM_EV_TOUCHED_HAZARD); {
-            efc.run(LeaderFsm::touchedHazard);
+            efc.run(GenMobFsm::touchHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(LeaderFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_DROP); {
             efc.changeState("drinking");
@@ -500,10 +500,10 @@ void LeaderFsm::createFsm(MobType* typ) {
             efc.changeState("knocked_down");
         }
         efc.newEvent(FSM_EV_TOUCHED_HAZARD); {
-            efc.run(LeaderFsm::touchedHazard);
+            efc.run(GenMobFsm::touchHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(LeaderFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_BOUNCER); {
             efc.run(LeaderFsm::beThrownByBouncer);
@@ -526,10 +526,10 @@ void LeaderFsm::createFsm(MobType* typ) {
             efc.changeState("inactive_knocked_down");
         }
         efc.newEvent(FSM_EV_TOUCHED_HAZARD); {
-            efc.run(LeaderFsm::touchedHazard);
+            efc.run(GenMobFsm::touchHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(LeaderFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_BOUNCER); {
             efc.run(LeaderFsm::beThrownByBouncer);
@@ -555,10 +555,10 @@ void LeaderFsm::createFsm(MobType* typ) {
             efc.run(LeaderFsm::beAttacked);
         }
         efc.newEvent(FSM_EV_TOUCHED_HAZARD); {
-            efc.run(LeaderFsm::touchedHazard);
+            efc.run(GenMobFsm::touchHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(LeaderFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_BOUNCER); {
             efc.run(LeaderFsm::beThrownByBouncer);
@@ -590,10 +590,10 @@ void LeaderFsm::createFsm(MobType* typ) {
             efc.run(LeaderFsm::beAttacked);
         }
         efc.newEvent(FSM_EV_TOUCHED_HAZARD); {
-            efc.run(LeaderFsm::touchedHazard);
+            efc.run(GenMobFsm::touchHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(LeaderFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_BOUNCER); {
             efc.run(LeaderFsm::beThrownByBouncer);
@@ -618,10 +618,10 @@ void LeaderFsm::createFsm(MobType* typ) {
             efc.run(LeaderFsm::beAttacked);
         }
         efc.newEvent(FSM_EV_TOUCHED_HAZARD); {
-            efc.run(LeaderFsm::touchedHazard);
+            efc.run(GenMobFsm::touchHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(LeaderFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_BOTTOMLESS_PIT); {
             efc.run(LeaderFsm::fallDownPit);
@@ -644,10 +644,10 @@ void LeaderFsm::createFsm(MobType* typ) {
             efc.run(LeaderFsm::beAttacked);
         }
         efc.newEvent(FSM_EV_TOUCHED_HAZARD); {
-            efc.run(LeaderFsm::touchedHazard);
+            efc.run(GenMobFsm::touchHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(LeaderFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_BOTTOMLESS_PIT); {
             efc.run(LeaderFsm::fallDownPit);
@@ -700,10 +700,10 @@ void LeaderFsm::createFsm(MobType* typ) {
             efc.changeState("inactive_thrown");
         }
         efc.newEvent(FSM_EV_TOUCHED_HAZARD); {
-            efc.run(LeaderFsm::touchedHazard);
+            efc.run(GenMobFsm::touchHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(LeaderFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(LeaderFsm::touchedSpray);
@@ -757,10 +757,10 @@ void LeaderFsm::createFsm(MobType* typ) {
             efc.changeState("inactive_riding_track");
         }
         efc.newEvent(FSM_EV_TOUCHED_HAZARD); {
-            efc.run(LeaderFsm::touchedHazard);
+            efc.run(GenMobFsm::touchHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(LeaderFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(LeaderFsm::touchedSpray);
@@ -800,10 +800,10 @@ void LeaderFsm::createFsm(MobType* typ) {
             efc.run(LeaderFsm::startGoHere);
         }
         efc.newEvent(FSM_EV_TOUCHED_HAZARD); {
-            efc.run(LeaderFsm::touchedHazard);
+            efc.run(GenMobFsm::touchHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(LeaderFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(LeaderFsm::touchedSpray);
@@ -874,10 +874,10 @@ void LeaderFsm::createFsm(MobType* typ) {
             efc.run(LeaderFsm::startGoHere);
         }
         efc.newEvent(FSM_EV_TOUCHED_HAZARD); {
-            efc.run(LeaderFsm::touchedHazard);
+            efc.run(GenMobFsm::touchHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(LeaderFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(LeaderFsm::touchedSpray);
@@ -945,10 +945,10 @@ void LeaderFsm::createFsm(MobType* typ) {
             efc.run(LeaderFsm::startGoHere);
         }
         efc.newEvent(FSM_EV_TOUCHED_HAZARD); {
-            efc.run(LeaderFsm::touchedHazard);
+            efc.run(GenMobFsm::touchHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(LeaderFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(LeaderFsm::touchedSpray);
@@ -994,10 +994,10 @@ void LeaderFsm::createFsm(MobType* typ) {
             efc.run(LeaderFsm::startGoHere);
         }
         efc.newEvent(FSM_EV_TOUCHED_HAZARD); {
-            efc.run(LeaderFsm::touchedHazard);
+            efc.run(GenMobFsm::touchHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(LeaderFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(LeaderFsm::touchedSpray);
@@ -1030,10 +1030,10 @@ void LeaderFsm::createFsm(MobType* typ) {
             efc.run(LeaderFsm::beAttacked);
         }
         efc.newEvent(FSM_EV_TOUCHED_HAZARD); {
-            efc.run(LeaderFsm::touchedHazard);
+            efc.run(GenMobFsm::touchHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(LeaderFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(LeaderFsm::touchedSpray);
@@ -1057,10 +1057,10 @@ void LeaderFsm::createFsm(MobType* typ) {
             efc.run(LeaderFsm::startWakingUp);
         }
         efc.newEvent(FSM_EV_TOUCHED_HAZARD); {
-            efc.run(LeaderFsm::touchedHazard);
+            efc.run(GenMobFsm::touchHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(LeaderFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(LeaderFsm::touchedSpray);
@@ -1087,10 +1087,10 @@ void LeaderFsm::createFsm(MobType* typ) {
             efc.run(LeaderFsm::startWakingUp);
         }
         efc.newEvent(FSM_EV_TOUCHED_HAZARD); {
-            efc.run(LeaderFsm::touchedHazard);
+            efc.run(GenMobFsm::touchHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(LeaderFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(LeaderFsm::touchedSpray);
@@ -1131,10 +1131,10 @@ void LeaderFsm::createFsm(MobType* typ) {
             efc.changeState("ko");
         }
         efc.newEvent(FSM_EV_TOUCHED_HAZARD); {
-            efc.run(LeaderFsm::touchedHazard);
+            efc.run(GenMobFsm::touchHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(LeaderFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(LeaderFsm::touchedSpray);
@@ -1153,10 +1153,10 @@ void LeaderFsm::createFsm(MobType* typ) {
             efc.run(LeaderFsm::land);
         }
         efc.newEvent(FSM_EV_TOUCHED_HAZARD); {
-            efc.run(LeaderFsm::touchedHazard);
+            efc.run(GenMobFsm::touchHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(LeaderFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(LeaderFsm::touchedSpray);
@@ -1178,10 +1178,10 @@ void LeaderFsm::createFsm(MobType* typ) {
             efc.run(LeaderFsm::land);
         }
         efc.newEvent(FSM_EV_TOUCHED_HAZARD); {
-            efc.run(LeaderFsm::touchedHazard);
+            efc.run(GenMobFsm::touchHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(LeaderFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(LeaderFsm::touchedSpray);
@@ -1209,10 +1209,10 @@ void LeaderFsm::createFsm(MobType* typ) {
             efc.run(LeaderFsm::beAttacked);
         }
         efc.newEvent(FSM_EV_TOUCHED_HAZARD); {
-            efc.run(LeaderFsm::touchedHazard);
+            efc.run(GenMobFsm::touchHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(LeaderFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(LeaderFsm::touchedSpray);
@@ -2184,25 +2184,6 @@ void LeaderFsm::land(ScriptVM* scriptVM, void* info1, void* info2) {
 
 
 /**
- * @brief When a leader leaves a hazardous sector.
- *
- * @param scriptVM The script VM responsible.
- * @param info1 Points to the hazard.
- * @param info2 Unused.
- */
-void LeaderFsm::leftHazard(ScriptVM* scriptVM, void* info1, void* info2) {
-    Leader* leaPtr = (Leader*) scriptVM->mob;
-    Hazard* h = (Hazard*) info1;
-    
-    engineAssert(info1 != nullptr, scriptVM->fsm.getStateHistoryStr());
-    
-    if(h->associatedLiquid) {
-        leaPtr->deleteParticleGenerator(MOB_PARTICLE_GENERATOR_ID_WAVE_RING);
-    }
-}
-
-
-/**
  * @brief When a leader should lose his momentum and stand still.
  *
  * @param scriptVM The script VM responsible.
@@ -2986,62 +2967,6 @@ void LeaderFsm::tickTrackRide(ScriptVM* scriptVM, void* info1, void* info2) {
             scriptVM->fsm.setState(LEADER_STATE_ACTIVE, nullptr, nullptr);
         } else {
             scriptVM->fsm.setState(LEADER_STATE_IDLING, nullptr, nullptr);
-        }
-    }
-}
-
-
-/**
- * @brief When a leader touches a hazard.
- *
- * @param scriptVM The script VM responsible.
- * @param info1 Pointer to the hazard.
- * @param info2 Pointer to the hitbox that caused this, if any.
- */
-void LeaderFsm::touchedHazard(ScriptVM* scriptVM, void* info1, void* info2) {
-    Leader* leaPtr = (Leader*) scriptVM->mob;
-    Hazard* hazPtr = (Hazard*) info1;
-    
-    engineAssert(info1 != nullptr, scriptVM->fsm.getStateHistoryStr());
-    
-    HitboxInteraction* hitboxInfo = (HitboxInteraction*) info2;
-    MobType::Vulnerability vuln = leaPtr->getHazardVulnerability(hazPtr);
-    Mob* hitboxMob = nullptr;
-    if(hitboxInfo) hitboxMob = hitboxInfo->mob2;
-    
-    if(!vuln.statusToApply || !vuln.statusOverrides) {
-        forIdx(e, hazPtr->effects) {
-            leaPtr->applyStatus(hazPtr->effects[e], false, true, hitboxMob);
-        }
-    }
-    if(vuln.statusToApply) {
-        leaPtr->applyStatus(vuln.statusToApply, false, true, hitboxMob);
-    }
-    
-    if(hazPtr->associatedLiquid) {
-        bool alreadyGenerating = false;
-        forIdx(g, leaPtr->particleGenerators) {
-            if(
-                leaPtr->particleGenerators[g].id ==
-                MOB_PARTICLE_GENERATOR_ID_WAVE_RING
-            ) {
-                alreadyGenerating = true;
-                break;
-            }
-        }
-        
-        if(!alreadyGenerating) {
-            ParticleGenerator pg =
-                standardParticleGenSetup(
-                    game.sysContentNames.parWaveRing, leaPtr
-                );
-            pg.followZOffset = 1.0f;
-            adjustKeyframeInterpolatorValues<float>(
-                pg.baseParticle.size,
-            [ = ] (const float & f) { return f * leaPtr->radius; }
-            );
-            pg.id = MOB_PARTICLE_GENERATOR_ID_WAVE_RING;
-            leaPtr->particleGenerators.push_back(pg);
         }
     }
 }

--- a/source/source/content/mob_script/leader_fsm.hpp
+++ b/source/source/content/mob_script/leader_fsm.hpp
@@ -89,7 +89,6 @@ void stopInGroup(ScriptVM* scriptVM, void* info1, void* info2);
 void stopWhistle(ScriptVM* scriptVM, void* info1, void* info2);
 void tickActiveState(ScriptVM* scriptVM, void* info1, void* info2);
 void tickTrackRide(ScriptVM* scriptVM, void* info1, void* info2);
-void touchedHazard(ScriptVM* scriptVM, void* info1, void* info2);
 void touchedSpray(ScriptVM* scriptVM, void* info1, void* info2);
 void trySetCorrectStandingAnim(ScriptVM* scriptVM, void* info1, void* info2);
 void updateInGroupChasing(ScriptVM* scriptVM, void* info1, void* info2);

--- a/source/source/content/mob_script/pikmin_fsm.cpp
+++ b/source/source/content/mob_script/pikmin_fsm.cpp
@@ -86,7 +86,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::touchedHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_BOTTOMLESS_PIT); {
             efc.run(PikminFsm::fallDownPit);
@@ -148,7 +148,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::touchedHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(PikminFsm::touchedSpray);
@@ -211,7 +211,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::touchedHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(PikminFsm::touchedSpray);
@@ -274,7 +274,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::touchedHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(PikminFsm::touchedSpray);
@@ -347,7 +347,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::touchedHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(PikminFsm::touchedSpray);
@@ -384,7 +384,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::touchedHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(PikminFsm::touchedSpray);
@@ -422,7 +422,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::touchedHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(PikminFsm::touchedSpray);
@@ -461,7 +461,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::touchedHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(PikminFsm::touchedSpray);
@@ -515,7 +515,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::touchedHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(PikminFsm::touchedSpray);
@@ -587,7 +587,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::touchedHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(PikminFsm::touchedSpray);
@@ -627,7 +627,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::touchedHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(PikminFsm::touchedSpray);
@@ -669,7 +669,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::touchedHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(PikminFsm::touchedSpray);
@@ -714,7 +714,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::touchedHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(PikminFsm::touchedSpray);
@@ -763,7 +763,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::touchedHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(PikminFsm::touchedSpray);
@@ -805,7 +805,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::touchedHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(PikminFsm::touchedSpray);
@@ -851,7 +851,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::touchedHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(PikminFsm::touchedSpray);
@@ -890,7 +890,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::touchedHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(PikminFsm::touchedSpray);
@@ -927,7 +927,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::touchedHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(PikminFsm::touchedSpray);
@@ -970,7 +970,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::touchedHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(PikminFsm::touchedSpray);
@@ -995,7 +995,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::touchedHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
     }
     
@@ -1031,7 +1031,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::touchedHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(PikminFsm::touchedSpray);
@@ -1070,7 +1070,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::touchedHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(PikminFsm::touchedSpray);
@@ -1109,7 +1109,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::touchedHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(PikminFsm::touchedSpray);
@@ -1152,7 +1152,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::touchedHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(PikminFsm::touchedSpray);
@@ -1190,7 +1190,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::touchedHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(PikminFsm::touchedSpray);
@@ -1228,7 +1228,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::touchedHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(PikminFsm::touchedSpray);
@@ -1264,7 +1264,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::touchedHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(PikminFsm::touchedSpray);
@@ -1289,7 +1289,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::touchedHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(PikminFsm::touchedSpray);
@@ -1319,7 +1319,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::touchedHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(PikminFsm::touchedSpray);
@@ -1341,7 +1341,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::becomeHelpless);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_HITBOX_TOUCH_EAT); {
             efc.run(PikminFsm::touchedEatHitbox);
@@ -1372,7 +1372,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::flailToLeader);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_HITBOX_TOUCH_EAT); {
             efc.run(PikminFsm::touchedEatHitbox);
@@ -1401,7 +1401,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::panicNewChase);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_HITBOX_TOUCH_EAT); {
             efc.run(PikminFsm::touchedEatHitbox);
@@ -1426,7 +1426,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::touchedHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_WHISTLED); {
             efc.run(PikminFsm::called);
@@ -1465,7 +1465,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::touchedHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_SPOT_IS_FAR); {
             efc.run(PikminFsm::updateInGroupChasing);
@@ -1520,7 +1520,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::touchedHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(PikminFsm::touchedSpray);
@@ -1554,7 +1554,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::touchedHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(PikminFsm::touchedSpray);
@@ -1608,7 +1608,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::touchedHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(PikminFsm::touchedSpray);
@@ -1660,7 +1660,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::touchedHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(PikminFsm::touchedSpray);
@@ -1719,7 +1719,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::touchedHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(PikminFsm::touchedSpray);
@@ -1778,7 +1778,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::touchedHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(PikminFsm::touchedSpray);
@@ -1819,7 +1819,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::touchedHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(PikminFsm::touchedSpray);
@@ -1859,7 +1859,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::touchedHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(PikminFsm::touchedSpray);
@@ -1911,7 +1911,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::touchedHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(PikminFsm::touchedSpray);
@@ -1955,7 +1955,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::touchedHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(PikminFsm::touchedSpray);
@@ -1989,7 +1989,7 @@ void PikminFsm::createFsm(MobType* typ) {
             efc.run(PikminFsm::touchedHazard);
         }
         efc.newEvent(FSM_EV_LEFT_HAZARD); {
-            efc.run(PikminFsm::leftHazard);
+            efc.run(GenMobFsm::leaveHazard);
         }
         efc.newEvent(FSM_EV_TOUCHED_SPRAY); {
             efc.run(PikminFsm::touchedSpray);
@@ -3862,25 +3862,6 @@ void PikminFsm::leaveOnion(ScriptVM* scriptVM, void* info1, void* info2) {
 
 
 /**
- * @brief When a Pikmin leaves a hazardous sector.
- *
- * @param scriptVM The script VM responsible.
- * @param info1 Points to the hazard.
- * @param info2 Unused.
- */
-void PikminFsm::leftHazard(ScriptVM* scriptVM, void* info1, void* info2) {
-    Pikmin* pikPtr = (Pikmin*) scriptVM->mob;
-    Hazard* h = (Hazard*) info1;
-    
-    engineAssert(info1 != nullptr, scriptVM->fsm.getStateHistoryStr());
-    
-    if(h->associatedLiquid) {
-        pikPtr->deleteParticleGenerator(MOB_PARTICLE_GENERATOR_ID_WAVE_RING);
-    }
-}
-
-
-/**
  * @brief When the mob the Pikmin is latched on to disappears.
  *
  * @param scriptVM The script VM responsible.
@@ -4883,13 +4864,11 @@ void PikminFsm::touchedEatHitbox(ScriptVM* scriptVM, void* info1, void* info2) {
  */
 void PikminFsm::touchedHazard(ScriptVM* scriptVM, void* info1, void* info2) {
     Pikmin* pikPtr = (Pikmin*) scriptVM->mob;
-    Hazard* hazPtr = (Hazard*) info1;
-    
+
     engineAssert(info1 != nullptr, scriptVM->fsm.getStateHistoryStr());
     
-    Mob* hitboxMob = nullptr;
-    
     if(info2) {
+        Mob* hitboxMob = nullptr;
         //This is an attack.
         HitboxInteraction* hInfo = (HitboxInteraction*) info2;
         hitboxMob = hInfo->mob2;
@@ -4898,46 +4877,8 @@ void PikminFsm::touchedHazard(ScriptVM* scriptVM, void* info1, void* info2) {
             return;
         }
     }
-    
-    if(hazPtr->associatedLiquid) {
-        bool alreadyGenerating = false;
-        forIdx(g, pikPtr->particleGenerators) {
-            if(
-                pikPtr->particleGenerators[g].id ==
-                MOB_PARTICLE_GENERATOR_ID_WAVE_RING
-            ) {
-                alreadyGenerating = true;
-                break;
-            }
-        }
-        
-        if(!alreadyGenerating) {
-            ParticleGenerator pg =
-                standardParticleGenSetup(
-                    game.sysContentNames.parWaveRing, pikPtr
-                );
-            pg.followZOffset = 1.0f;
-            adjustKeyframeInterpolatorValues<float>(
-                pg.baseParticle.size,
-            [ = ] (const float & f) { return f * pikPtr->radius; }
-            );
-            pg.id = MOB_PARTICLE_GENERATOR_ID_WAVE_RING;
-            pikPtr->particleGenerators.push_back(pg);
-        }
-    }
-    
-    if(pikPtr->invulnPeriod.timeLeft > 0) return;
-    MobType::Vulnerability vuln = pikPtr->getHazardVulnerability(hazPtr);
-    if(vuln.effectMult == 0.0f) return;
-    
-    if(!vuln.statusToApply || !vuln.statusOverrides) {
-        forIdx(e, hazPtr->effects) {
-            pikPtr->applyStatus(hazPtr->effects[e], false, true, hitboxMob);
-        }
-    }
-    if(vuln.statusToApply) {
-        pikPtr->applyStatus(vuln.statusToApply, false, true, hitboxMob);
-    }
+    //Run default code beyond this.
+    GenMobFsm::touchHazard(scriptVM, info1, info2);
 }
 
 

--- a/source/source/content/mob_script/pikmin_fsm.hpp
+++ b/source/source/content/mob_script/pikmin_fsm.hpp
@@ -72,7 +72,6 @@ void landOnMob(ScriptVM* scriptVM, void* info1, void* info2);
 void landOnMobWhileHolding(ScriptVM* scriptVM, void* info1, void* info2);
 void landWhileHolding(ScriptVM* scriptVM, void* info1, void* info2);
 void leaveOnion(ScriptVM* scriptVM, void* info1, void* info2);
-void leftHazard(ScriptVM* scriptVM, void* info1, void* info2);
 void loseLatchedMob(ScriptVM* scriptVM, void* info1, void* info2);
 void notifyLeaderRelease(ScriptVM* scriptVM, void* info1, void* info2);
 void panicNewChase(ScriptVM* scriptVM, void* info1, void* info2);

--- a/source/source/content/mob_type/mob_type.cpp
+++ b/source/source/content/mob_type/mob_type.cpp
@@ -136,7 +136,7 @@ void MobType::handleLoadedFsmState(FsmStateDef* state) {
         );
     }
     
-    //Inject a hazard event.
+    //Inject hazard events.
     if(
         !state->events[FSM_EV_TOUCHED_HAZARD] &&
         !isInContainer(statesIgnoringHazard, state->name)
@@ -147,6 +147,18 @@ void MobType::handleLoadedFsmState(FsmStateDef* state) {
         );
         newEvents.push_back(
             new FsmEventDef(FSM_EV_TOUCHED_HAZARD, haActions)
+        );
+    }
+    if(
+        !state->events[FSM_EV_LEFT_HAZARD] &&
+        !isInContainer(statesIgnoringHazard, state->name)
+    ) {
+        vector<ScriptActionDef*> haActions;
+        haActions.push_back(
+            new ScriptActionDef(GenMobFsm::leaveHazard)
+        );
+        newEvents.push_back(
+            new FsmEventDef(FSM_EV_LEFT_HAZARD, haActions)
         );
     }
     


### PR DESCRIPTION
Removes all duplicate touched hazard code, and runs it all under `GenMobFsm::touchHazard()`.

Effects on gameplay
- Mobs now properly respect sector hazard vulnerabilities. Previously, hazards always applied their effects, regardless of vulnerability.
- All mobs now emit wave particles when in liquid.