### PR TITLE
Mobs now initialize their Z value before running on_enter

### DIFF
--- a/source/source/content/mob/mob.cpp
+++ b/source/source/content/mob/mob.cpp
@@ -3684,10 +3684,12 @@ Mob* Mob::spawn(const MobType::SpawnInfo* info, MobType* typePtr) {
             newXY,
             typePtr,
             newAngle,
-            info->varsStr
+            info->varsStr,
+            nullptr, 
+            INVALID, 
+            newZ
         );
         
-    newMob->bottomZ = newZ;
     
     if(typePtr->category->id == MOB_CATEGORY_TREASURES) {
         //This way, treasures that fall into the abyss respawn at the

--- a/source/source/content/mob/mob_utils.cpp
+++ b/source/source/content/mob/mob_utils.cpp
@@ -1313,6 +1313,7 @@ float calculateMobPhysicalSpan(
  * @param codeAfterCreation Code to run right after the mob is created,
  * if any. This is run before any scripting takes place.
  * @param firstStateOverride If this is INVALID, use the first state
+ * @param z If this is INVALID, use the default z
  * index defined in the mob's FSM struct, or the standard first state index.
  * Otherwise, use this.
  * @return The new mob.
@@ -1321,11 +1322,16 @@ Mob* createMob(
     MobCategory* category, const Point& center, MobType* type,
     float angle, const string& varsStr,
     std::function<void(Mob*)> codeAfterCreation,
-    size_t firstStateOverride
+    size_t firstStateOverride, const float z
 ) {
     //Create the mob from the category.
     Mob* mPtr = category->createMob(center, type, angle);
     
+    //Set the z position if necessary.
+    if(z != INVALID) {
+        mPtr->bottomZ = z;
+    }
+
     //Immediate post-creation logic, if any.
     if(codeAfterCreation) {
         codeAfterCreation(mPtr);

--- a/source/source/content/mob/mob_utils.hpp
+++ b/source/source/content/mob/mob_utils.hpp
@@ -815,7 +815,7 @@ Mob* createMob(
     MobCategory* category, const Point& pos, MobType* type,
     float angle, const string& varsStr,
     std::function<void(Mob*)> codeAfterCreation = nullptr,
-    size_t firstStateOverride = INVALID
+    size_t firstStateOverride = INVALID, const float z = INVALID
 );
 Mob* createMob(MobGen* gen);
 void deleteMob(Mob* m, bool completeDestruction = false);


### PR DESCRIPTION
This resulted in a bug where spawning explosions were always considered grounded.